### PR TITLE
use_cache now defaults false not true

### DIFF
--- a/org/opentreeoflife/server/Services.java
+++ b/org/opentreeoflife/server/Services.java
@@ -136,10 +136,10 @@ public class Services {
     private HttpHandler conflictStatus =
         wrapCGItoJSON(new CGItoJSON() {
                 public JSONObject run(Map<String, String> parameters) {
-                    boolean useCache = true;
+                    boolean useCache = false;
                     String useCacheParam = parameters.get("use_cache");
-                    if (useCacheParam != null && useCacheParam.equals("false"))
-                        useCache = false;
+                    if (useCacheParam != null && useCacheParam.equals("true"))
+                        useCache = true;
                     return conflictStatus(parameters.get("tree1"),
                                           parameters.get("tree2"),
                                           useCache);


### PR DESCRIPTION
The cache business didn't really work - if the study changed, the new version wouldn't get picked up.
You can still use use_cache=true to use the cache, as an optimization, when you think it will be valid. 

(one study is always cached, but the cache will be ignored by default, and only consulted when use_cache=true.)

Tested on devapi
