### PR TITLE
Enable use of conflict analysis with non-nexson trees

### DIFF
--- a/org/opentreeoflife/conflict/ConflictAnalysis.java
+++ b/org/opentreeoflife/conflict/ConflictAnalysis.java
@@ -188,17 +188,6 @@ public class ConflictAnalysis {
         if (refnode != null
             && (includeSuppressed || !refnode.isHidden())) {
             map.put(node, refnode);
-            // Invert
-            Taxon othernode = comap.get(refnode);
-            if (othernode == null) {
-                comap.put(refnode, node);
-                return true;
-            } else
-                // Multiple input nodes map to a single ref node.
-                // Map only one of them to the ref node, leaving the
-                // others unmapped.
-                // TBD: exemplars and/or least id
-                return false;
         }
         return false;
     }

--- a/org/opentreeoflife/conflict/ConflictAnalysis.java
+++ b/org/opentreeoflife/conflict/ConflictAnalysis.java
@@ -126,23 +126,35 @@ public class ConflictAnalysis {
     Map<Taxon, Taxon> invertMap(Map<Taxon, Taxon> map) {
         Map<Taxon, Taxon> comap = new HashMap<Taxon, Taxon>();
         Set<Taxon> ambiguous = new HashSet<Taxon>(); // set of ambiguous ref nodes
+        int collisions = 0;
         for (Taxon node : map.keySet()) {
             Taxon refnode = map.get(node);
             if (!ambiguous.contains(refnode)) {
                 Taxon othernode = comap.get(refnode);
                 if (othernode != null) {
-                    // maybe do mrca instead ?
-                    // or, lexicographically least ?
-                    // if (node.id.compareTo(othernode.id) < 0) comap.put(refnode, othernode);
-                    // OR: comap.put(refnode, othernode.mrca(node));
-                    comap.remove(refnode);
-                    ambiguous.add(refnode);
+                    ++collisions;
+                    // Things one might do when there is a collision:
+                    // 1. take the mrca
+                    //     comap.put(refnode, othernode.mrca(node));
+                    // 2. lexicographically least
+                    //     if (node.id.compareTo(othernode.id) < 0) comap.put(refnode, othernode);
+                    // 3. remove entirely
+                    //     comap.remove(refnode); ambiguous.add(refnode);
+                    // 4. first come first served
+                    //     ;
+                    if (true) {
+                        if (node.id.compareTo(othernode.id) < 0)
+                            comap.put(refnode, othernode);
+                    } else {
+                        comap.remove(refnode);
+                        ambiguous.add(refnode);
+                    } 
                 } else
                     comap.put(refnode, node);
             }
         }
-        if (ambiguous.size() > 0)
-            System.out.format("* %s collisions\n", ambiguous.size());
+        if (collisions > 0)
+            System.out.format("* %s collisions\n", collisions);
         return comap;
     }
 

--- a/org/opentreeoflife/conflict/ConflictAnalysis.java
+++ b/org/opentreeoflife/conflict/ConflictAnalysis.java
@@ -14,6 +14,7 @@ import org.opentreeoflife.taxa.Taxon;
 import org.opentreeoflife.taxa.Taxonomy;
 import org.opentreeoflife.taxa.SourceTaxonomy;
 import org.opentreeoflife.taxa.QualifiedId;
+import org.opentreeoflife.smasher.Alignment;
 
 public class ConflictAnalysis {
 
@@ -22,41 +23,57 @@ public class ConflictAnalysis {
     public Taxonomy ref;
 
     // The Taxonomy class allows multiple roots, but we can only deal with one
-    Taxon inputRoot = null;
-    Taxon refRoot = null;
+    public Taxon inputRoot;
+    public Taxon refRoot;
 
+    public Taxon ingroup = null;              // node in input, either ingroup or root
     public Taxon inducedRoot = null;          // node in ref induced by whole input
     public Taxon inducedIngroup = null;       // node in ref induced by ingroup
 
-    public Taxon ingroup = null;              // node in input
-
-    public Map<Taxon, Taxon> map = new HashMap<Taxon, Taxon>(); // input -> ref
-    public Map<Taxon, Taxon> comap = new HashMap<Taxon, Taxon>(); // ref -> input
+    public Map<Taxon, Taxon> map; // input -> ref
+    public Map<Taxon, Taxon> comap; // ref -> input
 
     public int conflicting = 0;
     public int opportunities = 0;
 
-    boolean includeIncertaeSedis;
+    boolean includeSuppressed;
 
     public ConflictAnalysis(Taxonomy input, Taxonomy ref) {
-        
-        this(input, ref, input.ingroupId, true);
+        this(input, ref, null, true);
     }
+    /*
+    // deprecated
     public ConflictAnalysis(Taxonomy input, Taxonomy ref, String ingroupId) {
-        this(input, ref, ingroupId, true);
+        if (input.ingroup == null) input.ingroup = input.lookupId(ingroupId);
+        this(input, ref, true);
     }
-    public ConflictAnalysis(Taxonomy input, Taxonomy ref, String ingroupId, boolean includeIncertaeSedis) {
+    // deprecated
+    public ConflictAnalysis(Taxonomy input, Taxonomy ref, String ingroupId, boolean includeSuppressed) {
+        if (input.ingroup == null) input.ingroup = input.lookupId(ingroupId);
+        this(input, ref, includeSuppressed);
+    }
+    */
+
+    public ConflictAnalysis(Taxonomy input, Taxonomy ref, Alignment alignment, boolean includeSuppressed) {
         this.input = input;
         this.ref = ref;
         this.inputRoot = uniqueRoot(input);
         this.refRoot = uniqueRoot(ref);
+
+        // Populate map and comap
+        map = new HashMap<Taxon, Taxon>();
+        if (alignment == null) {
+            this.mapTips(this.inputRoot);
+        } else {
+            for (Taxon node : alignment.keySet())
+                // might want to restrict this to tips
+                map.put(node, alignment.getTaxon(node));
+        }
+        comap = this.invertMap(map);
         this.induce();
 
-        if (ingroupId == null)
-            ingroupId = input.ingroupId;
-
-        if (ingroupId != null)
-            this.ingroup = input.lookupId(ingroupId);
+        // Establish ingroups
+        this.ingroup = input.ingroup;
         if (this.ingroup == null)
             this.ingroup = inputRoot;
         this.inducedIngroup = map.get(this.ingroup);
@@ -104,9 +121,48 @@ public class ConflictAnalysis {
             return 0;
     }
 
-    // Map tips bidirectionally
+    // Compute comap from map
 
-    boolean mapTip(Taxon node, Taxonomy ref) {
+    Map<Taxon, Taxon> invertMap(Map<Taxon, Taxon> map) {
+        Map<Taxon, Taxon> comap = new HashMap<Taxon, Taxon>();
+        Set<Taxon> ambiguous = new HashSet<Taxon>(); // set of ambiguous ref nodes
+        for (Taxon node : map.keySet()) {
+            Taxon refnode = map.get(node);
+            if (!ambiguous.contains(refnode)) {
+                Taxon othernode = comap.get(refnode);
+                if (othernode != null) {
+                    // maybe do mrca instead ?
+                    // or, lexicographically least ?
+                    // if (node.id.compareTo(othernode.id) < 0) comap.put(refnode, othernode);
+                    // OR: comap.put(refnode, othernode.mrca(node));
+                    comap.remove(refnode);
+                    ambiguous.add(refnode);
+                } else
+                    comap.put(refnode, node);
+            }
+        }
+        if (ambiguous.size() > 0)
+            System.out.format("* %s collisions\n", ambiguous.size());
+        return comap;
+    }
+
+    // Map tips bidirectionally
+    // node is a node in the input tree
+
+    boolean mapTips(Taxon node) {
+        boolean anyMapped = false;
+        if (node.children != null) {
+            for (Taxon child : node.children)
+                anyMapped = mapTips(child) || anyMapped;
+        }
+        if (!anyMapped) {
+            mapTip(node);
+            return true;
+        } else
+            return false;
+    }
+
+    boolean mapTip(Taxon node) {
         String id = null;
         if (node.taxonomy.idspace.equals(ref.idspace)) // useful for testing
             id = node.id;
@@ -116,27 +172,21 @@ public class ConflictAnalysis {
                     id = qid.id;
                     break;
                 }
-        Taxon node2 = ref.lookupId(id);
-        if (node2 != null
-            && (includeIncertaeSedis || !node2.isHidden())) {
-            Taxon othernode = comap.get(node2);
+        Taxon refnode = ref.lookupId(id);
+        if (refnode != null
+            && (includeSuppressed || !refnode.isHidden())) {
+            map.put(node, refnode);
+            // Invert
+            Taxon othernode = comap.get(refnode);
             if (othernode == null) {
-                map.put(node, node2);
-                comap.put(node2, node);
+                comap.put(refnode, node);
                 return true;
             } else
                 // Multiple input nodes map to a single ref node.
                 // Map only one of them to the ref node, leaving the
                 // others unmapped.
+                // TBD: exemplars and/or least id
                 return false;
-        } else if (false && node.name != null) {
-            Taxon probe = ref.unique(node.name);
-            if (probe != null) {
-                // There are lots of these e.g. all of Metalasia in pg_1572
-                System.out.format("OTU autolookup? %s\n", probe);
-                // map.put(node, probe);
-                // comap.put(probe, node);
-            }
         }
         return false;
     }
@@ -163,10 +213,6 @@ public class ConflictAnalysis {
 
     // This runs twice, once in each direction input->ref / ref->input
     Taxon induce(Taxon node, Taxonomy other, Map<Taxon, Taxon> map) {
-        if (false) {
-            Taxon probe = map.get(node);
-            if (probe != null) return probe; // encountered as tip in other direction
-        }
         if (node.children != null) {
             Taxon mrca = null;
             for (Taxon child : node.children) {
@@ -183,8 +229,6 @@ public class ConflictAnalysis {
             }
             /* fall through - node is a 'virtual tip' */
         }
-        if (other == this.ref) // kludge
-            mapTip(node, other);
         return map.get(node);
     }
 

--- a/org/opentreeoflife/conflict/Disposition.java
+++ b/org/opentreeoflife/conflict/Disposition.java
@@ -1,10 +1,16 @@
 package org.opentreeoflife.conflict;
 
 public enum Disposition {
-    NONE,
-    CONFLICTS_WITH,
-    RESOLVES,
-    SUPPORTED_BY,
-    PATH_SUPPORTED_BY,
-    EXCLUDES,
+    NONE ("none"),
+    CONFLICTS_WITH ("conflicts_with"),
+    RESOLVES ("resolves"),
+    SUPPORTED_BY ("supported_by"),
+    PATH_SUPPORTED_BY ("partial_path_of"),
+    EXCLUDES ("excludes");
+
+    public String name;
+
+    Disposition(String name) {
+        this.name = name;
+    }
 }

--- a/org/opentreeoflife/smasher/Alignment.java
+++ b/org/opentreeoflife/smasher/Alignment.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Collection;
+import java.util.Set;
 
 import org.opentreeoflife.taxa.Node;
 import org.opentreeoflife.taxa.Taxon;
@@ -52,6 +53,10 @@ public class Alignment {
         start();
     }
 
+    public Set<Taxon> keySet() {
+        return mappings.keySet();
+    }
+
     private void start() {
         target.eventLogger.resetEvents();
         this.reset();          // depths, brackets, comapped
@@ -76,7 +81,7 @@ public class Alignment {
         }
     }
 
-    Taxon getTaxon(Taxon node) {
+    public Taxon getTaxon(Taxon node) {
         Answer a = mappings.get(node);
         if (a == null) return null;
         else if (a.isYes()) return a.target;

--- a/org/opentreeoflife/smasher/AlignmentByName.java
+++ b/org/opentreeoflife/smasher/AlignmentByName.java
@@ -23,7 +23,7 @@ import org.opentreeoflife.taxa.QualifiedId;
 
 public class AlignmentByName extends Alignment {
 
-    AlignmentByName(Taxonomy source, Taxonomy target) {
+    public AlignmentByName(Taxonomy source, Taxonomy target) {
         super(source, target);
     }
 

--- a/org/opentreeoflife/taxa/Answer.java
+++ b/org/opentreeoflife/taxa/Answer.java
@@ -25,10 +25,6 @@ public class Answer {
             !(subject.taxonomy instanceof SourceTaxonomy))
             throw new RuntimeException(String.format("Subject %s of new Answer is not in a source taxonomy",
                                                      subject));
-        if (target != null &&
-            (target.taxonomy instanceof SourceTaxonomy))
-            throw new RuntimeException(String.format("Target %s of new Answer is not in a union taxonomy",
-                                                     target));
 		this.subject = subject;
         this.target = target;
 		this.value = value;

--- a/org/opentreeoflife/taxa/Nexson.java
+++ b/org/opentreeoflife/taxa/Nexson.java
@@ -141,7 +141,9 @@ public class Nexson {
         }
 
         // Set the ingroup
-        tax.ingroupId = (String)treeson.get("^ot:inGroupClade");
+        String ingroupId = (String)treeson.get("^ot:inGroupClade");
+        if (ingroupId != null)
+            tax.ingroup = tax.lookupId(ingroupId);
 
         // Set the root
         String rootid = (String)treeson.get("^ot:rootNodeId");
@@ -156,10 +158,9 @@ public class Nexson {
                     if (spec != null) {
                         System.err.format("** Specified root %s not= represented root %s - rerooting NYI (%s)\n",
                                           specid, rootid, tag);
-                        Taxon ingroup = tax.ingroupId == null ? null : tax.lookupId(tax.ingroupId);
-                        if (ingroup != null && !ingroup.descendsFrom(spec))
+                        if (tax.ingroup != null && !tax.ingroup.descendsFrom(spec))
                             System.err.format("** BAD: Ingroup %s does not descend from specified root %s (%s)\n",
-                                              tax.ingroupId, specid, tag);
+                                              tax.ingroup.id, specid, tag);
                     }
                 }
                 tax.addRoot(node);

--- a/org/opentreeoflife/taxa/Taxon.java
+++ b/org/opentreeoflife/taxa/Taxon.java
@@ -442,7 +442,7 @@ public class Taxon extends Node {
             else if (this.parent == null)
                 ids = this.taxonomy.getIdspace() + ":<detached>";
             else
-                ids = "~";
+                ids = this.taxonomy.getIdspace() + ":";
         } else if (this.id != null)
             ids = this.id;
         else

--- a/org/opentreeoflife/taxa/Taxonomy.java
+++ b/org/opentreeoflife/taxa/Taxonomy.java
@@ -47,7 +47,7 @@ public abstract class Taxonomy {
 	Integer infocolumn = null;
 	Integer flagscolumn = null;
 	public JSONObject properties = new JSONObject();
-    public String ingroupId = null;    // for trees, not taxonomies
+    public Taxon ingroup = null;    // for trees, not taxonomies
 
 	private String tag = null;     // unique marker
 	private int taxid = -1234;	   // kludge

--- a/util/analyze_conflict.py
+++ b/util/analyze_conflict.py
@@ -1,0 +1,85 @@
+# Takes two trees, and does a conflict analysis of the second
+# against the first.
+# Typically the first ("reference") taxonomy would be OTT.
+
+# Trees are specified using any of the following forms (those accepted
+# by getTaxonomy):
+# 1. literal Newick string e.g.  (a,(b,c))d
+# 2. Newick string in a file, name ending in .tre
+# 3. 'interim taxonomy format', directory name, with a / at the end
+
+# Give a short 'idspace' tag for each - choice doesn't matter much.
+# E.g. 'ott' for OTT.  These show up in the output.
+
+# E.g.
+#  bin/jython util/analyze_conflict.py tax/ott/ ott scratch/Ruggiero/ rugg
+
+import sys
+
+from org.opentreeoflife.taxa import Taxonomy
+from org.opentreeoflife.smasher import AlignmentByName
+from org.opentreeoflife.conflict import ConflictAnalysis
+
+def conflict(spec1, space1, spec2, space2):
+
+    # Reference tree
+    ref = Taxonomy.getTaxonomy(spec1, space1)
+
+    # Input tree
+    input = Taxonomy.getTaxonomy(spec2, space2)
+
+    a = AlignmentByName(input, ref)
+    a.align();
+
+    if False:
+        for node in input.taxa():
+            print node, a.getTaxon(node)
+
+    print 'Conflict analysis'
+    ca = ConflictAnalysis(input, ref, a, False)
+    print '  input root:', ca.inputRoot
+    print '  ref root:', ca.refRoot
+    print '  induced root:', ca.inducedRoot
+    print '  ingroup:', ca.ingroup
+    print '  induced ingroup:', ca.inducedIngroup
+    print '  map size:', ca.map.size()
+    print '  comap size:', ca.comap.size()
+
+    mapped_tip_count = 0
+    unmapped_tip_count = 0
+    none_count = 0
+
+    rel_counts = {}
+
+    if ca.inducedRoot != None:
+        for node in ca.ingroup.descendants(True):
+            if node.hasChildren():
+                art = ca.articulation(node)
+                if art != None:
+                    n = art.disposition.name
+                    print node, n, art.witness
+                    rel_counts[n] = rel_counts.get(n, 0) + 1
+                else:
+                    print node, 'no articulation'
+                    none_count += 1
+            elif a.getTaxon(node) != None:
+                mapped_tip_count += 1
+            else:
+                unmapped_tip_count += 1
+                print node, 'unmapped'
+    else:
+        print 'no induced root!'
+
+    print
+    for n in rel_counts:
+        print '%s: %s' % (n, rel_counts[n])
+    print 'Mapped tips:', mapped_tip_count
+    print 'Unmapped tips:', unmapped_tip_count
+    print 'Other:', none_count
+
+# conflict('((a,b)ab,c,d)ee', 'x', '(a,(b,c)bc,d)e', 'y')
+# conflict('tax/silva/', 'silva', 'scratch/Ruggiero/', 'rug')
+
+conflict(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+
+# bin/jython scratch/conflict_test.py old/ott2.10draft11/ ott scratch/Ruggiero/ rug


### PR DESCRIPTION
Allow use of ConflictAnalysis class from python or Java where the input tree is not nexson-derived and an Alignment is provided to map the input tree to the reference tree.
(Formerly the input tree had to come from a nexson file and the mapping came from ^ot:ottId properties.)
