### PR TITLE
Conflict service now returns synth node ids

### DIFF
--- a/org/opentreeoflife/conflict/ConflictAnalysis.java
+++ b/org/opentreeoflife/conflict/ConflictAnalysis.java
@@ -415,7 +415,7 @@ public class ConflictAnalysis {
         // If node conflicts with anything, it conflicts with one of conode's children
         // That is, if node either contains or excludes every child of
         // conode, then node resolves conode, otherwise it conflicts.
-        for (Taxon cochild : conode.children) {
+        for (Taxon cochild : conode.getChildren()) {
             Taxon back = comap.get(cochild);
             if (back == null)
                 ;

--- a/org/opentreeoflife/conflict/ConflictAnalysis.java
+++ b/org/opentreeoflife/conflict/ConflictAnalysis.java
@@ -381,19 +381,15 @@ public class ConflictAnalysis {
     public static boolean maximizeWitness = true;
 
     public Articulation articulation(Taxon node, Map<Taxon, Taxon> map, Map<Taxon, Taxon> comap) {
-        Taxon conode = map.get(node);
+        Taxon conode = map.get(node); // usually in ref. taxonomy
         if (conode == null)
             return null;
-        Taxon bounce = comap.get(conode);
+        Taxon bounce = comap.get(conode); // back in original taxonomy
         if (bounce == null) {
             System.err.format("Shouldn't happen 1 %s\n", node);
             return null; // shouldn't happen
         }
         if (node.mrca(bounce) == node) {  // bounce <= node?
-
-            // TODO: Generalize this!
-            if (node.children == null || conode.children == null)
-                return new Articulation(Disposition.TIP, conode);
 
             Taxon witness = conode;
             if (maximizeWitness)
@@ -411,10 +407,6 @@ public class ConflictAnalysis {
         if (node.parent == null) {
             System.err.format("Shouldn't happen 2 %s\n", node);
             return null; // shouldn't happen
-        }
-        if (conode.children == null) {
-            System.err.format("** Articulation: shouldn't happen\n");
-            return null;
         }
 
         // ???? in (a,(b,c)) vs. (a,b,c)  (b,c) conflicts with a ????

--- a/org/opentreeoflife/conflict/Disposition.java
+++ b/org/opentreeoflife/conflict/Disposition.java
@@ -6,7 +6,8 @@ public enum Disposition {
     RESOLVES ("resolves"),
     SUPPORTED_BY ("supported_by"),
     PATH_SUPPORTED_BY ("partial_path_of"),
-    EXCLUDES ("excludes");
+    EXCLUDES ("excludes"),
+    TIP ("tip");
 
     public String name;
 

--- a/org/opentreeoflife/server/Services.java
+++ b/org/opentreeoflife/server/Services.java
@@ -43,8 +43,6 @@ public class Services {
     private static final int STATUS_METHOD_NOT_ALLOWED = 405;
     private static final String ALLOWED_METHODS = "OPTIONS,GET";
 
-    private static final String idspace = "ott";
-
     private Taxonomy referenceTaxonomy;
     private Taxonomy syntheticTree;
     private String studyBase;
@@ -58,9 +56,9 @@ public class Services {
     static int port = 8081;
 
     public static void main(final String... args) throws IOException {
-        new Services(args.length > 0 ? Taxonomy.getTaxonomy(args[0], idspace) : null,
-                     args.length > 1 ? Taxonomy.getTaxonomy(args[1], idspace) : null,
-                     args.length > 2 ? args[2] : "https://api.opentreeoflife.org/v2/study/")
+        new Services(args.length > 0 ? Taxonomy.getRawTaxonomy(args[0], "ott") : null,
+                     args.length > 1 ? Taxonomy.getRawTaxonomy(args[1], "synth") : null,
+                     args.length > 2 ? args[2] : "https://api.opentreeoflife.org/v3/study/")
             .serve("localhost", port);
     }
 
@@ -158,19 +156,23 @@ public class Services {
             Taxonomy tree2 = specToTree(treespec2, useCache);
             if (tree2 == null)
                 throw new BadRequest(String.format("Can't find %s", treespec2));
-            return conflictStatus(tree1, tree2);
+            return conflictStatus(tree1, tree2, true);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static JSONObject conflictStatus(Taxonomy tree1, Taxonomy tree2) {
+    public static JSONObject conflictStatus(Taxonomy tree1, Taxonomy tree2, boolean includeSuppressed) {
         boolean flipped = false;
         Taxonomy input = tree1, ref = tree2;
         if (tree2.count() < tree1.count()) { // heuristic!
             input = tree2; ref = tree1; flipped = true;
         }
-        ConflictAnalysis c = new ConflictAnalysis(input, ref);
+        ConflictAnalysis c;
+        if (ref.idspace.equals("synth"))
+            c = ConflictAnalysis.againstSynthesis(input, ref, includeSuppressed);
+        else
+            c = new ConflictAnalysis(input, ref);
         return conflictAnalysisToJSON(c, flipped);
     }
 
@@ -186,13 +188,12 @@ public class Services {
                 System.err.format("** id-less node %s\n", node);
                 continue;
             }
-            if (!node.hasChildren())
-                continue;
             Articulation a = c.articulation(node);
             if (a == null) continue;
             String tag = null;
             switch (a.disposition) {
-            case NONE: break;
+            case NONE:
+                break;
             case SUPPORTED_BY:
                 tag = "supported_by";
                 break;
@@ -206,15 +207,20 @@ public class Services {
             case CONFLICTS_WITH:
                 tag = "conflicts_with";
                 break;
+            case TIP:
+                // these don't tell the webapp anything it doesn't already know
+                break;
             }
             if (tag != null) {
                 JSONObject info = new JSONObject();
-                Taxon w = a.witness;
+                Taxon w = a.witness; // in ref
                 if (w != null) {
                     if (w.id != null && !w.id.startsWith("-"))
                         info.put("witness", w.id);
                     if (w.name != null)
                         info.put("witness_name", w.name);
+                    // TBD: Fill in synth node names from taxonomy by peeling
+                    // off the "ott" prefix and looking up in OTT
                 }
                 info.put("status", tag);
                 result.put(node.id, info);
@@ -224,7 +230,9 @@ public class Services {
     }
 
     public Taxonomy specToTree(String spec, boolean useCache) throws IOException {
-        String[] parts = spec.split("#");
+        String delim = "#";
+        if (spec.contains("@")) delim = "@";
+        String[] parts = spec.split(delim);
         if (parts.length == 0)
             throw new BadRequest("Empty tree specifier");
         else if (parts.length == 1)
@@ -233,11 +241,11 @@ public class Services {
         else if (parts.length == 2)
             return getSourceTree(parts[0], parts[1], useCache);
         else
-            throw new BadRequest(String.format("Too many #'s: %s", spec));
+            throw new BadRequest(String.format("Too many %s's: %s", delim, spec));
     }
 
     private Taxonomy getReferenceTree(String spec) {
-        if (spec.startsWith(idspace))
+        if (spec.startsWith("ott"))
             return referenceTaxonomy;
         else if (spec.startsWith("synth"))
             return syntheticTree;

--- a/org/opentreeoflife/server/Services.java
+++ b/org/opentreeoflife/server/Services.java
@@ -186,6 +186,8 @@ public class Services {
                 System.err.format("** id-less node %s\n", node);
                 continue;
             }
+            if (!node.hasChildren())
+                continue;
             Articulation a = c.articulation(node);
             if (a == null) continue;
             String tag = null;

--- a/org/opentreeoflife/server/Services.java
+++ b/org/opentreeoflife/server/Services.java
@@ -66,6 +66,16 @@ public class Services {
         this.referenceTaxonomy = reftax;
         this.syntheticTree = synth;
         this.studyBase = studyBase;
+        int count = 0;
+        for (Taxon node : synth.taxa())
+            if (node.name == null && node.id.startsWith("ott")) {
+                Taxon ottnode = reftax.lookupId(node.id.substring(3));
+                if (ottnode != null) {
+                    node.setName(ottnode.name);
+                    ++count;
+                }
+            }
+        System.out.format("| Transferred %s names from OTT to synthetic tree\n", count);
     }
 
     // Does not return

--- a/org/opentreeoflife/smasher/AlignmentByName.java
+++ b/org/opentreeoflife/smasher/AlignmentByName.java
@@ -167,14 +167,12 @@ public class AlignmentByName extends Alignment {
             lg.add(start);
         }
 
-        Taxon anyCandidate = null;
         Answer result = null;
         for (Criterion criterion : criteria) {
             List<Answer> answers = new ArrayList<Answer>(candidates.size());
             int max = -100;
             int count = 0;  // number of candidates that have the max value
             Answer anyAnswer = null;
-            anyCandidate = null;
             for (Taxon cand : candidates) {
                 Answer a = criterion.assess(node, cand);
                 if (a.subject != null) lg.add(a);
@@ -184,7 +182,6 @@ public class AlignmentByName extends Alignment {
                         max = a.value;
                         count = 1;
                         anyAnswer = a;
-                        anyCandidate = cand;
                     } else if (a.value == max)
                         count++;
                 }
@@ -225,11 +222,14 @@ public class AlignmentByName extends Alignment {
         }
 
         if (result == null) {   // ended up with noinfo.
-            target.markEvent("used: elimination");
             // Singleton
-            if (candidates.size() == 1)
-                result = Answer.yes(node, anyCandidate, "elimination", null);
-            else if (!node.hasChildren())
+            if (candidates.size() == 1) {
+                target.markEvent("by elimination");
+                for (Taxon cand : candidates) {
+                    result = Answer.yes(node, cand, "elimination", null);
+                    break;
+                }
+            } else if (!node.hasChildren())
                 // Ambiguous.  Avoid creating yet another homonym.  
                 result = Answer.noinfo(node, null, "ambiguous tip", null);
             else

--- a/org/opentreeoflife/taxa/Answer.java
+++ b/org/opentreeoflife/taxa/Answer.java
@@ -145,6 +145,10 @@ public class Answer {
 
 
     public String toString() {
-        return String.format("(%s %s)", this.value, this.reason);
+        return String.format("(%s %s %s %s)",
+                             this.subject != null ? this.subject : "-",
+                             this.target != null ? this.target : "-",
+                             this.value,
+                             this.reason);
     }
 }

--- a/org/opentreeoflife/taxa/CSVReader.java
+++ b/org/opentreeoflife/taxa/CSVReader.java
@@ -1,0 +1,90 @@
+/*
+  CSVReader reader = new CSVReader(new FileReader("yourfile.csv"), '\t');
+     // feed in your array (or convert your data to an array)
+     String[] entries = "first#second#third".split("#");
+     reader.writeNext(entries);
+	 reader.close();
+*/
+
+package org.opentreeoflife.taxa;
+
+import java.io.Reader;
+import java.io.IOException;
+import java.io.Closeable;
+import java.util.regex.Pattern;
+import java.util.Scanner;
+import java.util.List;
+import java.util.ArrayList;
+
+// s.nextLine()
+
+
+// having this implement Iterable<String[]> would be nice...
+
+public class CSVReader implements Closeable {
+
+    Reader reader;
+    Scanner scanner;
+
+    public CSVReader(Reader reader) {
+        this.reader = reader;
+        this.scanner = new Scanner(reader);
+    }
+
+    static final char SEP = ',';
+    static final char QUOTE = '\'';
+
+    public String[] readNext() throws IOException {
+        if (!scanner.hasNext()) return null;
+        String line = scanner.nextLine();
+        if (line == null) return null;
+
+        int i = 0;
+        int stop = line.length();
+        List<String> result = new ArrayList<String>();
+        StringBuilder bu = new StringBuilder();
+        while (i < stop) {
+            char c = line.charAt(i++);
+            if (c == SEP) {
+                result.add(bu.toString());
+                bu.setLength(0);
+            } else if (c == QUOTE)
+                while (i < stop) {
+                    c = line.charAt(i++);
+                    if (c == QUOTE) {
+                        if ((i+1) < stop && line.charAt(i+1) == QUOTE)
+                            i++;
+                        else
+                            break;
+                    }
+                    bu.append(c);
+                }
+            else
+                bu.append(c);
+        }
+        result.add(bu.toString());
+        return result.toArray(dummy);
+    }
+
+    private final String[] dummy = new String[]{};
+
+    public void close() throws IOException {
+        reader.close();
+    }
+
+    public static void main(String[] args) throws Exception {
+        CSVReader r = new CSVReader(new java.io.StringReader("a,b,c\nc,b,a\nd,'e',f\ng,'h''h',i"));
+        String[] row = null;
+        while (true) {
+            row = r.readNext();
+            if (row == null) break;
+            for (int i = 0; i < row.length; ++i) {
+                if (i > 0)
+                    System.out.print(" | ");
+                System.out.print(row[i]);
+            }
+            System.out.println();
+        }
+    }
+
+}

--- a/org/opentreeoflife/taxa/SimpleMap.java
+++ b/org/opentreeoflife/taxa/SimpleMap.java
@@ -1,0 +1,7 @@
+
+package org.opentreeoflife.taxa;
+
+public interface SimpleMap<D, R> {
+    R get(D key);
+}
+

--- a/org/opentreeoflife/taxa/Taxon.java
+++ b/org/opentreeoflife/taxa/Taxon.java
@@ -179,11 +179,11 @@ public class Taxon extends Node {
     // Returns number of synonyms created.
 
     public int copySynonymsTo(Taxon targetTaxon) {
-        Taxon taxon = this;
         int count = 0;
-        if (targetTaxon.addSynonym(this, "synonym") != null)
-            ++count;
-        for (Synonym syn : taxon.getSynonyms())
+        if (this.name != null)
+            if (targetTaxon.addSynonym(this, "synonym") != null)
+                ++count;
+        for (Synonym syn : this.getSynonyms())
             if (targetTaxon.addSynonym(syn, syn.type) != null)
                 ++count;
         return count;
@@ -702,12 +702,19 @@ public class Taxon extends Node {
 
 	static Comparator<Taxon> compareNodes = new Comparator<Taxon>() {
 		public int compare(Taxon x, Taxon y) {
-            if (x.name != null && y.name != null)
-                return x.name.compareTo(y.name);
-            else if (x.id != null && y.id != null)
+            if (x.id != null || y.id != null) {
+                // sort nodes with ids before ones without
+                if (x.id == null) return 1;
+                if (y.id == null) return -1;
                 return x.id.compareTo(y.id);
-            else
-                return 0;
+            } else if (x.name != null || y.name != null) {
+                // sort named nodes before unnamed ones
+                if (x.name == null) return 1;
+                if (y.name == null) return -1;
+                return x.name.compareTo(y.name);
+            } else
+                // grasp at straws
+                return x.getChildren().size() - y.getChildren().size();
 		}
 	};
 

--- a/org/opentreeoflife/taxa/Taxonomy.java
+++ b/org/opentreeoflife/taxa/Taxonomy.java
@@ -175,15 +175,15 @@ public abstract class Taxonomy {
     }
 
     // utility
-	public Taxon unique(String name) {
-		List<Node> probe = this.lookup(name);
+	public Taxon unique(String designator) {
+		List<Node> probe = this.lookup(designator);
 		if (probe != null) {
             if (probe.size() == 1)
                 return probe.get(0).taxon();
             else
                 return null;
 		} else 
-			return this.lookupId(name);
+			return this.lookupId(designator);
 	}
 
     // Every taxonomy has an idspace, even if not every node has an id.
@@ -1199,8 +1199,8 @@ public abstract class Taxonomy {
 		for (Taxon cutting : cuttings) {
 			PrintStream out = 
 				openw(outprefix + cutting.name.replaceAll(" ", "_") + ".tre");
-			StringBuffer buf = new StringBuffer();
-			Newick.appendNewickTo(cutting, true, buf);
+			StringBuilder buf = new StringBuilder();
+			Newick.appendNewickTo(cutting, Newick.USE_NAMES_AND_IDS, buf);
 			out.print(buf.toString());
 			out.close();
 		}
@@ -1348,13 +1348,17 @@ public abstract class Taxonomy {
 	// This feature is very primitive and only intended for debugging purposes!
 
 	public String toNewick() {
-        return this.toNewick(true);
+        return this.toNewick(Newick.USE_NAMES_AND_IDS);
     }
 
 	public String toNewick(boolean useIds) {
-		StringBuffer buf = new StringBuffer();
+        return toNewick(useIds ? Newick.USE_NAMES_AND_IDS : Newick.USE_NAMES);
+    }
+
+	public String toNewick(int mode) {
+		StringBuilder buf = new StringBuilder();
 		for (Taxon root: this.roots()) {
-			Newick.appendNewickTo(root, useIds, buf);
+			Newick.appendNewickTo(root, mode, buf);
 			buf.append(";");
 		}
 		return buf.toString();

--- a/service/Makefile
+++ b/service/Makefile
@@ -1,0 +1,9 @@
+
+
+labelled_supertree.tre:
+	curl http://files.opentreeoflife.org/synthesis/opentree7.0/opentree7.0_tree/labelled_supertree/labelled_supertree.tre >labelled_supertree.tre.new
+	mv labelled_supertree.tre.new labelled_supertree.tre
+
+asterales.tre:
+	../bin/jython ../util/select_from_taxonomy.py labelled_supertree.tre ott1042120 asterales.new.tre
+	mv asterales.new.tre asterales.tre

--- a/service/Makefile
+++ b/service/Makefile
@@ -3,8 +3,7 @@ refresh-synth: labelled_supertree.tre
 	ln -sf labelled_supertree.tre synth.tre
 
 labelled_supertree.tre:
-	curl http://files.opentreeoflife.org/synthesis/current/output/labelled_supertree/labelled_supertree.tre >labelled_supertree.tre.new
-	mv labelled_supertree.tre.new labelled_supertree.tre
+	wget http://files.opentreeoflife.org/synthesis/current/output/labelled_supertree/labelled_supertree.tre
 
 asterales.tre:
 	../bin/jython ../util/select_from_taxonomy.py labelled_supertree.tre ott1042120 asterales.new.tre

--- a/service/Makefile
+++ b/service/Makefile
@@ -1,9 +1,14 @@
 
+refresh-synth: labelled_supertree.tre
+	ln -sf labelled_supertree.tre synth.tre
 
 labelled_supertree.tre:
-	curl http://files.opentreeoflife.org/synthesis/opentree7.0/opentree7.0_tree/labelled_supertree/labelled_supertree.tre >labelled_supertree.tre.new
+	curl http://files.opentreeoflife.org/synthesis/current/output/labelled_supertree/labelled_supertree.tre >labelled_supertree.tre.new
 	mv labelled_supertree.tre.new labelled_supertree.tre
 
 asterales.tre:
 	../bin/jython ../util/select_from_taxonomy.py labelled_supertree.tre ott1042120 asterales.new.tre
 	mv asterales.new.tre asterales.tre
+
+clean:
+	rm labelled_supertree.tre

--- a/service/run_service
+++ b/service/run_service
@@ -15,6 +15,8 @@
 
 # Not a good location for this config file; fix later
 
+set -e
+
 . service.config
 
 # Modify as appropriate to your own hardware
@@ -48,8 +50,8 @@ else
   exit 1
 fi
 
-if "x$STUDY_BASE_URL" = x; then
-  STUDY_BASE_URL="https://api.opentreeoflife.org/v2/study/"
+if [ "x$STUDY_BASE_URL" = x ]; then
+  STUDY_BASE_URL="https://api.opentreeoflife.org/v3/study/"
 fi
 
 echo Starting services $TAXONOMY $SYNTH $STUDY_BASE_URL

--- a/util/select_from_taxonomy.py
+++ b/util/select_from_taxonomy.py
@@ -1,8 +1,19 @@
-from org.opentreeoflife.taxa import Taxonomy
-import sys
+import sys, codecs
+from org.opentreeoflife.taxa import Taxonomy, Newick
 
 source = sys.argv[1]    # Name of directory containing original taxonomy (must end in /)
 name = sys.argv[2]      # Name of taxon to extract
 dest = sys.argv[3]      # Directory to store result (must end in /)
 
-Taxonomy.getTaxonomy(source).select(name).dump(dest)
+if not (dest.endswith('/') or dest.endswith('.tre')):
+    print >>sys.stderr, 'Invalid taxonomy destination (need / or .tre)', dest
+    sys.exit(1)
+
+selection = Taxonomy.getRawTaxonomy(source, 'foo').select(name)
+
+if dest.endswith('.tre'):
+    with codecs.open(dest, 'w', 'utf-8') as outfile:
+        outfile.write(Newick.toNewick(selection, Newick.USE_NAMES_AND_IDS))
+        outfile.write('\n')
+else:
+    selection.dump(dest)

--- a/ws-tests/test_conflict_ott.py
+++ b/ws-tests/test_conflict_ott.py
@@ -7,22 +7,27 @@ from opentreetesting import get_obj_from_http, config
 
 DOMAIN = config('host', 'apihost')
 URL = DOMAIN + '/v2/conflict/compare'
-STUDY = 'pg_1700'
-TREE = 'tree3429'
+STUDY = 'pg_715'
+TREE = 'tree1289'
 REF = 'ott'
-TEST_NODE = u'node672503'
+TEST_NODE = u'node436083'
+WANT_WITNESS = u'503060'
 
 input = {'tree1': STUDY + '#' + TREE, 'tree2': 'ott'}
 result = get_obj_from_http(URL, verb='GET', params=input)
 
 if not TEST_NODE in result:
-    sys.stderr.write('node %s missing from result' % result)
+    sys.stderr.write('node %s missing from result %s' % (TEST_NODE, result))
     sys.exit(1)
-if not u'witness' in result[TEST_NODE]:
-    sys.stderr.write('missing witness; %s' % result[TEST_NODE])
+art = result[TEST_NODE]
+if not art[u'status'] == u'conflicts_with':
+    sys.stderr.write('unexpected relation; %s' % art)
     sys.exit(1)
-if result[TEST_NODE][u'witness'] != u'239671':
-    sys.stderr.write('bad witness %s' % result[TEST_NODE]['witness'])
+if not u'witness' in art:
+    sys.stderr.write('missing witness; %s' % art)
+    sys.exit(1)
+if art[u'witness'] != WANT_WITNESS:
+    sys.stderr.write('bad witness: %s, expected %s' % (art[u'witness'], WANT_WITNESS))
     sys.exit(1)
 sys.exit(0)
 

--- a/ws-tests/test_conflict_synth.py
+++ b/ws-tests/test_conflict_synth.py
@@ -4,8 +4,9 @@ import sys
 from opentreetesting import test_http_json_method, config
 
 DOMAIN = config('host', 'apihost')
-SUBMIT_URI = DOMAIN + '/v2/conflict/compare?tree1=pg_2100%23tree4347&tree2=synth'
-TEST_NODE = u'node794743'
+SUBMIT_URI = DOMAIN + '/v2/conflict/compare?tree1=pg_715%23tree1289&tree2=synth'
+TEST_NODE = u'node436069'
+WANT_WITNESS = u'mrcaott374954ott448619'  #hoping this will be stable
 
 # The study is chosen because if its small size.  The tree has only 7 OTUs.
 test, result = test_http_json_method(SUBMIT_URI, "GET",
@@ -16,10 +17,10 @@ if not test:
 if not TEST_NODE in result:
     sys.stderr.write('{} not in result {}\n'.format(TEST_NODE, result))
     sys.exit(1)
-item = result[TEST_NODE]
-if item.get(u'status') != u'resolves':
-    sys.stderr.write('{} does not resolve in {}\n'.format(TEST_NODE, result))
+art = result[TEST_NODE]
+if art.get(u'status') != u'conflicts_with':
+    sys.stderr.write('{} relation is not "resolves": {}\n'.format(TEST_NODE, art))
     sys.exit(1)
-if item.get(u'witness') != u'54936':
-    sys.stderr.write('{} does not have witness 54936 in {}\n'.format(TEST_NODE, result))
+if art.get(u'witness') != WANT_WITNESS:
+    sys.stderr.write('{} witness is {}; expected {}\n'.format(TEST_NODE, art.get(u'witness'), WANT_WITNESS))
     sys.exit(1)


### PR DESCRIPTION
The 'witness' is now provided for non-OTT synthetic tree nodes, in the form 'mrcaott1234ott5678'.  For OTT-identified nodes the witness is given as 'ott1234' (incompatible change; was '1234').

The curator app seems to handle this just fine.

This addresses #214.