### PR TITLE
Script for reading DwCA files of the sort that GBIF publishes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,10 +398,12 @@ r/gbif-HEAD/resource/.made: r/gbif-HEAD/work/projection.tsv \
 	mv r/gbif-HEAD/resource.new r/gbif-HEAD/resource
 	touch $@
 
-r/gbif-HEAD/work/projection.tsv: r/gbif-HEAD/source/.made \
-			     import_scripts/gbif/project_2016.py
+# The python script wants `pip install python-dwca-reader`
+
+r/gbif-HEAD/work/projection.tsv: r/gbif-HEAD/archive/.made \
+			     import_scripts/gbif/project.py
 	@mkdir -p `dirname $@`
-	python import_scripts/gbif/project_2016.py r/gbif-HEAD/source/taxon.txt $@.new
+	python import_scripts/gbif/project.py r/gbif-HEAD/archive/archive.zip $@.new
 	mv $@.new $@
 
 # Get a new GBIF from the web and store to r/gbif-HEAD/archive/archive.zip
@@ -418,7 +420,7 @@ refresh/gbif: r/gbif-NEW/source/.made
 
 r/gbif-NEW/source/.made: r/gbif-NEW/archive/.made
 	bin/unpack-archive gbif-NEW
-	d=`python util/modification_date.py r/gbif-NEW/source/taxon.txt`; \
+	d=`python util/modification_date.py r/gbif-NEW/source/eml.xml`; \
           bin/put gbif-NEW date $$d && \
           bin/put gbif-NEW version $$d
 

--- a/curation/adjustments.py
+++ b/curation/adjustments.py
@@ -1527,7 +1527,7 @@ def adjust_irmng(irmng):
     # if saxo != None:
     #     saxo.absorb(irmng.taxon('1071613'))
     # https://github.com/OpenTreeOfLife/reference-taxonomy/issues/50
-    irmng.taxon('Saxo-fridericia').synonym('Saxo-Fridericia'))
+    irmng.taxon('Saxo-fridericia').synonym('Saxo-Fridericia')
 
     # JAR 2015-06-28
     # The synonym Ochrothallus multipetalus -> Niemeyera multipetala

--- a/curation/adjustments.py
+++ b/curation/adjustments.py
@@ -763,8 +763,11 @@ def patch_ncbi(ncbi):
     ncbi.taxon('Pechuel-loeschea').synonym('Pechuel-Loeschea', 'spelling variant')
 
     # RR #50
-    ncbi.taxon('Saxofridericia').synonym('Saxo-Fridericia', 'spelling variant')
-    ncbi.taxon('Saxofridericia').synonym('Saxo-fridericia', 'spelling variant')
+    # ncbi.taxon('Saxofridericia').synonym('Saxo-Fridericia', 'spelling variant')
+    # ncbi.taxon('Saxofridericia').synonym('Saxo-fridericia', 'spelling variant')
+    # above reversed by https://github.com/OpenTreeOfLife/reference-taxonomy/issues/50
+    ncbi.taxon('Saxo-fridericia').synonym('Saxo-Fridericia', 'spelling variant')
+    ncbi.taxon('Saxo-fridericia').synonym('Saxofridericia', 'spelling variant')
 
     # RR #57
     ncbi.taxon('Solms-laubachia').synonym('Solms-Laubachia', 'spelling variant')
@@ -1231,8 +1234,8 @@ def patch_gbif(gbif):
     for (synonym, primary, qid) in [
             ('Chryso-Hypnum', 'Chryso-hypnum', otc('24')),  # 2014-04-13 JAR noticed while grepping
             ('Drake-Brockmania', 'Drake-brockmania', otc(2)),  # RR 2014-04-12 #47
-            ('Saxo-Fridericia', 'Saxofridericia',
-             otc(36, evidence='https://github.com/OpenTreeOfLife/feedback/issues/50')),  # RR #50 - this one is in NCBI, see above
+            ('Saxo-Fridericia', 'Saxo-fridericia',
+             otc(36, evidence='https://github.com/OpenTreeOfLife/reference-taxonomy/issues/50')),
             ('Solms-Laubachia', 'Solms-laubachia', otc(37)), # RR #57 - the genus is in NCBI, see above
             ('Solms-Laubachia pulcherrima', 'Solms-laubachia pulcherrima', otc(38)), # RR #57
             ('Cyrto-Hypnum', 'Cyrto-hypnum', otc(39)),
@@ -1517,9 +1520,11 @@ def adjust_irmng(irmng):
     # RR #50
     # irmng.taxon('Saxo-Fridericia').rename('Saxofridericia')
     # irmng.taxon('Saxofridericia').absorb(irmng.taxon('Saxo-fridericia'))
-    saxo = irmng.maybeTaxon('1063899')
-    if saxo != None:
-        saxo.absorb(irmng.taxon('1071613'))
+    # saxo = irmng.maybeTaxon('1063899')
+    # if saxo != None:
+    #     saxo.absorb(irmng.taxon('1071613'))
+    # https://github.com/OpenTreeOfLife/reference-taxonomy/issues/50
+    irmng.taxon('Saxo-fridericia').synonym('Saxo-Fridericia'))
 
     # JAR 2015-06-28
     # The synonym Ochrothallus multipetalus -> Niemeyera multipetala

--- a/curation/adjustments.py
+++ b/curation/adjustments.py
@@ -57,7 +57,7 @@ def deal_with_polysemies(ott):
     establish('Epiphloea', ott, division='Fungi',      source='if:1869', ott_id='5342482') #lichinales
     establish('Epiphloea', ott, division='Rhodophyta', source='ncbi:257604', ott_id='471770')  #florideophycidae
 
-    # Discovered on scrutinizing the log.  There's a third one but it gets 
+    # Discovered on scrutinizing the log.  There's a third one but it gets
     # separated automatically
     establish('Morganella', ott, division='Bacteria', source='ncbi:581', ott_id='524780') #also in silva
     establish('Morganella', ott, division='Fungi',    source='if:19222', ott_id='973932')
@@ -180,10 +180,10 @@ def patch_silva(silva):
     # JAR noticed failed inclusion test - this is fixed in silva 117
     silva.taxon('Bacteria').take(silva.maybeTaxon('Verrucomicrobia group'))
 
-    # EU930344	|	D78004/#6	|	Photorhabdus luminescens	|	samples	|	ncbi:1004165	|	
-    # EU930342	|	D78004/#6	|	Photorhabdus luminescens	|	samples	|	ncbi:1004166	|	
-    # 1004165	|	29488	|	Photorhabdus luminescens subsp. caribbeanensis	|	subspecies	|	
-    # 1004166	|	29488	|	Photorhabdus luminescens subsp. hainanensis	|	subspecies	|	
+    # EU930344	|	D78004/#6	|	Photorhabdus luminescens	|	samples	|	ncbi:1004165	|
+    # EU930342	|	D78004/#6	|	Photorhabdus luminescens	|	samples	|	ncbi:1004166	|
+    # 1004165	|	29488	|	Photorhabdus luminescens subsp. caribbeanensis	|	subspecies	|
+    # 1004166	|	29488	|	Photorhabdus luminescens subsp. hainanensis	|	subspecies	|
     silva.taxon('EU930344').clobberName('Photorhabdus luminescens subsp. caribbeanensis')
     silva.taxon('EU930342').clobberName('Photorhabdus luminescens subsp. hainanensis')
 
@@ -213,7 +213,7 @@ def patch_silva(silva):
 
     silva.taxon('Florideophycidae', 'Rhodophyceae').synonym('Florideophyceae')
 
-    # JAR 2016-07-29 I could find no argument supporting the name 
+    # JAR 2016-07-29 I could find no argument supporting the name
     # 'Choanomonada' as a replacement for 'Choanoflagellida'.  I
     # suggested to the SILVA folks that they change the name.
     silva.taxon('Choanomonada', 'Opisthokonta').rename('Choanoflagellida')
@@ -278,7 +278,7 @@ def align_silva(silva, ott):
     #       ott.taxon('641212'))
 
     # 2016-11-20 Force matches with NCBI and WoRMS Protaspis
-    # WoRMS says: "Protapsa Cavalier-Smith in Howe et al., 2011 was proposed 
+    # WoRMS says: "Protapsa Cavalier-Smith in Howe et al., 2011 was proposed
     # to replace Protaspis Skuja, 1939 under the ICZN"
     silva.taxon('Protaspa', 'Rhizaria').synonym('Protaspis')
 
@@ -501,7 +501,7 @@ def link_to_h2007(tax):
     establish('Lepidostromataceae', tax, parent='Lepidostromatales',
               division='Fungi', source='ncbi:579912')
     # In OTT 3.0 and Index Fungorum, Trichotheliaceae is listed as a
-    # synonym for Porinaceae.  But it seems to be accepted in Mycobank, 
+    # synonym for Porinaceae.  But it seems to be accepted in Mycobank,
     # and was given as accepted by Romina.
     # Not sure how the two relate.
 
@@ -519,9 +519,9 @@ def link_to_h2007(tax):
         [
          ('Neozygitaceae', 'Neozygitales', None),
          ('Asterinaceae', 'Asterinales', None),
-         ('Savoryella', 'Savoryellales', None), 
-         ('Ascotaiwania', 'Savoryellales', None), 
-         ('Ascothailandia', 'Savoryellales', None), 
+         ('Savoryella', 'Savoryellales', None),
+         ('Ascotaiwania', 'Savoryellales', None),
+         ('Ascothailandia', 'Savoryellales', None),
          ('Cladochytriaceae', 'Cladochytriales', None),
          ('Nowakowskiellaceae', 'Cladochytriales', None),
          ('Septochytriaceae', 'Cladochytriales', None),
@@ -1109,7 +1109,7 @@ def align_gbif(gbif, ott):
     # This one seems to have gone away given changes to GBIF
     # a.notSame(gbif.taxon('Gorkadinium', 'Dinophyta'),
     #              ott.taxon('Tetrasphaera', 'Intrasporangiaceae')) # = Tetrasphaera in Protozoa
-    
+
     # Rick Ree 2014-03-28 https://github.com/OpenTreeOfLife/reference-taxonomy/issues/37
     # ### CHECK - was ncbi.taxon
     # a.same(gbif.taxon('Calothrix', 'Rivulariaceae'), ott.taxon('Calothrix', 'Rivulariaceae'))
@@ -1131,7 +1131,7 @@ def align_gbif(gbif, ott):
     # JAR 2014-04-23 More sample contamination in SILVA 115
     # redundant
     # a.same(gbif.taxon('Lamprospora'), fungi.taxon('Lamprospora'))
-    
+
     # JAR 2014-04-23 IF update fallout
     # - CHECK - was ncbi.taxon
     a.same(gbif.taxonThatContains('Penicillium', 'Penicillium salamii'),
@@ -1206,7 +1206,7 @@ def align_gbif(gbif, ott):
     chon = gbif.maybeTaxon('Chondromyces', 'Fungi')
     if chon != None: chon.prune()
 
-    # 2017-03-26 This has been moved to Cercozoa - not a fungus.  See e.g. 
+    # 2017-03-26 This has been moved to Cercozoa - not a fungus.  See e.g.
     # the web version of Index Fungorum.
     plas = gbif.maybeTaxon('Plasmodiophora', 'Fungi')
     if plas != None: ott.setDivision(plas, 'SAR')
@@ -1339,14 +1339,14 @@ def patch_gbif(gbif):
                               taxon('Bdellidae'),
                               otc(47)))
 
-    # 2016-09-01 These are fossil fungi spores, not plants.  They're in 
+    # 2016-09-01 These are fossil fungi spores, not plants.  They're in
     # Index Fungorum, so we don't need wrong info from GBIF.
     inap = gbif.maybeTaxon('Inapertisporites', 'Plantae')
     if inap != None:
         inap.prune(this_source)
 
     # 2016-09-01 This is not a plant.  Checked W. van Hoven 1987, found
-    # in pubmed via web search, which says these things are ciliates, 
+    # in pubmed via web search, which says these things are ciliates,
     # and puts them in Cycloposthiidae.  http://dx.doi.org/10.1111/j.1550-7408.1987.tb03186.x
     # gbif.taxon('Cycloposthiidae').take(gbif.taxon('Monoposthium'))
 
@@ -1357,7 +1357,7 @@ def patch_gbif(gbif):
     bad_ecc = gbif.maybeTaxon('Eccrinaceae', 'Zygomycota')
     if bad_ecc != None: bad_ecc.prune()
 
-    # 2016-11-15 Noticed these while perusing the deprecated.tsv after the 
+    # 2016-11-15 Noticed these while perusing the deprecated.tsv after the
     # GBIF 2016 update.  GBIF has corrected the gender on many species names.
     # These are the ones occurring in phylesystem.
     for (name, wrong_name) in [
@@ -1399,7 +1399,7 @@ def patch_gbif(gbif):
     # GBIF changed Chaetocalyx longiflora to -us.
     # GBIF changed Collocalia spodiopygia to -us.
 
-    # 2016-11-18 These GBIF duplicates show up as ambiguous while processing 
+    # 2016-11-18 These GBIF duplicates show up as ambiguous while processing
     # the chromista spreadsheet.
     for (name, bad_id) in [
             ('Rhaphidoscene', '7738163'),
@@ -1418,38 +1418,16 @@ def patch_gbif(gbif):
         tax = gbif.taxon(name, 'Foraminifera')
         if tax != None and gbif.maybeTaxon(bad_id) != None:
             tax.absorb(gbif.taxon(bad_id))
-    
+
     # 2016-11-20 Diaphoropodon showed up as ambiguous in transcript.
     # There are two Diaphoropodon in new GBIF (4898754 + 8212987).
     # 4 is a foram, 8 is a 'Sarcomastigophora', which is paraphyletic.
-    # OTT thinks Sarc. is inconsistent.  8 is a child of 
+    # OTT thinks Sarc. is inconsistent.  8 is a child of
     # Chlamydophryidae -- which is in SAR!  So these two things are
     # actually the same.
     # 2017-06-04 The one in Sarcomastigophora has been removed from GBIF online.
     if gbif.maybeTaxon('Diaphoropodon', 'Sarcomastigophora') != None:
         gbif.taxon('Diaphoropodon', 'Sarcomastigophora').prune(otc(48))
-
-    # GBIF has two taxa Rotalites and two synonym Rotalites.  That
-    # seems excessive.
-    # 7966169	|	8376456	|	Rotalites	|	genus	|	 8376456 = Foraminifera
-    # 8101279	|	7	|	Rotalites	|	genus	|	     7 = Protozoa
-    # synonym 8063968	|	Rotalites	|	proparte synonym	|	Rotalia in Foraminifer
-    # synonym 8376456	|	Rotalites	|	proparte synonym	|	8376456 = Foraminifera
-    # I think these are all the same.
-    # Rotalites is also a proparte synonym in worms and irmng.
-    # There's also Rotalia, two of them in gbif, both genera:
-    # 7996474  parent 1 (! Animalia)
-    # 8063968 parent 7475854 = Rotaliidae
-    # Let's make them all the same as 8063968.
-    rotalia = gbif.taxon('Rotalia', 'Foraminifera')
-    foram = gbif.taxon('Foraminifera')
-    for lites in [r for r in gbif.lookup('Rotalites')]:
-        if (lites.name == 'Rotalites' and
-            lites.taxon() == lites and
-            lites.descendsFrom(foram)):
-            rotalia.absorb(lites, 'proparte synonym', otc(49))
-    # Blow away distracting synonym
-    foram.notCalled('Rotalites')
 
     # Similar cases (probably): (from Chromista spreadsheet ambiguities)
     # Umbellina, Rotalina
@@ -1543,8 +1521,8 @@ def adjust_irmng(irmng):
 
     # JAR 2015-06-28
     # The synonym Ochrothallus multipetalus -> Niemeyera multipetala
-    # is no good; it interferes with correct processing of Ochrothallus 
-    # multipetalus.  We could remove the synonym, but instead remove its 
+    # is no good; it interferes with correct processing of Ochrothallus
+    # multipetalus.  We could remove the synonym, but instead remove its
     # target because no synonym-removal command is available.
     irmng.taxon('Niemeyera multipetala').prune(this_source)
 
@@ -1588,7 +1566,7 @@ def adjust_irmng(irmng):
     if irmng.maybeTaxon('Notochelys', 'Cheloniidae') != None:
         irmng.taxon('Notochelys', 'Cheloniidae').prune(this_source)
 
-    # JAR 2016-07-04 Duplicates of leps in Diptera, noticed when reviewing 
+    # JAR 2016-07-04 Duplicates of leps in Diptera, noticed when reviewing
     # homonym report
     for (id, name) in [('10888189', 'Aricia brunnescens'),
                        ('10095324', 'Aricia deleta'),
@@ -1734,7 +1712,7 @@ def align_irmng(irmng, ott):
     # Noticed while scanning species polysemies
     irmng.taxon('Peranemaceae').take(irmng.maybeTaxon('Heteronema', 'Rhodophyta'))
 
-    # 2016-10-28 Noticed Goeppertia wrongly extinct while eyeballing 
+    # 2016-10-28 Noticed Goeppertia wrongly extinct while eyeballing
     # the deprecated.tsv file
     goe = irmng.maybeTaxon('Goeppertia', 'Pteridophyta')
     if goe != None:
@@ -1765,7 +1743,7 @@ def align_irmng(irmng, ott):
 
     # Yan Wong https://github.com/OpenTreeOfLife/feedback/issues/345
     # Conolophus should synonymized with Minchenella... see comments
-    # Minchenella is known to newer GBIF, but not to older IRMNG, so this 
+    # Minchenella is known to newer GBIF, but not to older IRMNG, so this
     # should align now.
     if irmng.maybeTaxon('Conolophus', 'Mammalia') != None:
         irmng.taxon('Conolophus', 'Mammalia').clobberName('Minchenella')

--- a/curation/adjustments.py
+++ b/curation/adjustments.py
@@ -1448,7 +1448,9 @@ def patch_gbif(gbif):
     # Exists in other taxonomies in correct place, so we simply prune it from gbif
     # (using the incorrect parent, so that we will get it back in corrected future
     # updates
-    gbif.taxon("Placopecten","Pectiniidae").prune()
+    placo = gbif.maybeTaxon("Placopecten")
+    if placo != None:
+        gbif.taxon("Placopecten","Pectiniidae").prune()
 
     return gbif
 

--- a/curation/adjustments.py
+++ b/curation/adjustments.py
@@ -1448,7 +1448,7 @@ def patch_gbif(gbif):
     # Exists in other taxonomies in correct place, so we simply prune it from gbif
     # (using the incorrect parent, so that we will get it back in corrected future
     # updates
-    placo = gbif.maybeTaxon("Placopecten")
+    placo = gbif.maybeTaxon("Placopecten","Pectiniidae")
     if placo != None:
         gbif.taxon("Placopecten","Pectiniidae").prune()
 

--- a/curation/adjustments.py
+++ b/curation/adjustments.py
@@ -1056,7 +1056,8 @@ def align_gbif(gbif, ott):
            ott.taxon('Cyclophora', 'SAR'))
 
     # GBIF puts this one directly in Animalia, but Annelida is a barrier node
-    gbif.taxon('Annelida').take(gbif.taxon('Echiura'))
+    # 2019-10-28 Echiura no longer in GBIF
+    # gbif.taxon('Annelida').take(gbif.taxon('Echiura'))
     # similarly
     gbif.taxon('Cnidaria').take(gbif.taxon('Myxozoa'))
 
@@ -1118,8 +1119,9 @@ def align_gbif(gbif, ott):
     # a.same(gbif.taxon('Calothrix', 'Rivulariaceae'), ott.taxon('Calothrix', 'Rivulariaceae'))
     a.same(gbif.taxon('Chlorella', 'Chlorellaceae'),
            ott.taxon('Chlorella', 'Chlorellaceae'))
-    a.same(gbif.taxonThatContains('Myrmecia', 'Myrmecia irregularis'),
-           ott.taxonThatContains('Myrmecia', 'Myrmecia irregularis'))
+    # 2019=10-28 Myrmecia the plant no longer exists in GBIF
+    # a.same(gbif.taxonThatContains('Myrmecia', 'Myrmecia irregularis'),
+    #       ott.taxonThatContains('Myrmecia', 'Myrmecia irregularis'))
 
     # JAR 2014-04-18 attempt to resolve ambiguous alignment of
     # Trichosporon in IF and GBIF based on common member

--- a/curation/adjustments.py
+++ b/curation/adjustments.py
@@ -1581,8 +1581,8 @@ def adjust_irmng(irmng):
     for (id, name) in [('10888189', 'Aricia brunnescens'),
                        ('10095324', 'Aricia deleta'),
                        ('10094174', 'Aricia striata')]:
-        tax = irmng.maybeTaxon(id)
-        if tax != None: tax.prune(this_source)
+                       tax = irmng.maybeTaxon(id)
+                       if tax != None: tax.prune(this_source)
 
     # 2016-07-28 JAR
     # Discovered by ambiguity in an inclusion test.  The IRMNG genus appears to be

--- a/curation/adjustments.py
+++ b/curation/adjustments.py
@@ -1194,7 +1194,8 @@ def align_gbif(gbif, ott):
 
     # 2016-12-18 somehow came loose.  4738987 = apusozoan, 570408 = plant
     # Without this, the plant was lumping in with the apusozoan.
-    a.same(gbif.taxon('3236805'), ott.taxon('4738987'))
+    # In gbif-20190916, id 3236805 no longer exists
+    # a.same(gbif.taxon('3236805'), ott.taxon('4738987'))
     a.same(gbif.taxon('3033928'), ott.taxon('570408'))
 
     # 2016-11-20 Showed up as ambiguous in transcript; log says ncbi and gbif records are separated because disjoint.

--- a/doc/maintenance/errors.md
+++ b/doc/maintenance/errors.md
@@ -101,7 +101,7 @@ not something obscure.  To determine where it is in the draft OTT, we
 can use `bin/lineage`:
 
     bin/lineage 591146 r/ott-NEW/source
-    591146	639691	Enidae	family	ncbi:145762,gbif:2297508,irmng:114831		merged,hidden_inherited,barren	
+    591146	639691	Enidae	family	ncbi:145762,gbif:2297508,irmng:114831		merged,hidden_inherited,barren
     639691	329706	Enoidea	superfamily	ncbi:145342		hidden_inherited
     329706	844843	Sigmurethra	no rank	ncbi:216366		hidden_inherited
     844843	379916	Stylommatophora	infraorder	ncbi:6527,gbif:1456,irmng:10595		hidden_inherited
@@ -270,17 +270,17 @@ applied to GBIF but not to IRMNG.
 
     ** No such taxon: Myrmecia in Microthamniales (gbif)
 
-This comes from 
+This comes from
 
     a.same(gbif.taxon('Myrmecia', 'Microthamniales'),
            ott.taxon('Myrmecia', 'Microthamniales'))
 
 in adjustments.py.  In `r/gbif-HEAD/resource/taxonomy.tsv'` we see
 
-    1317709	|	4342	|	Myrmecia	|	genus	|	
-    2638661	|	6784730	|	Myrmecia	|	genus	|	
+    1317709	|	4342	|	Myrmecia	|	genus	|
+    2638661	|	6784730	|	Myrmecia	|	genus	|
 
-    1360	|	332	|	Microthamniales	|	order	|	
+    1360	|	332	|	Microthamniales	|	order	|
 
 so it's strange that the patch doesn't work.  Using the OTT taxonomy
 browser, we find that _Myrmecia_ (genus in order Microthamniales) is
@@ -495,6 +495,30 @@ These names are gone from the sources and the taxonomy, so they don't
 matter.  To make the errors go away, delete the patches (or comment
 them out - in case the problem returns later on).
 
+### Requested name / parent not the same as prior
+
+These errors happen when processing additions from the amendments repository
+(the patches created by users in the web application when curating phylogenies).
+The error comes from the [getAddedTaxon](https://github.com/OpenTreeOfLife/reference-taxonomy/blob/1a9da1ee50b328e1973743647007c2b7d488b773/org/opentreeoflife/taxa/Addition.java#L207) method in Addition.java.
+
+Looking at this error:
+
+`** Requested parent 5807594 not same as prior parent 3344074 for Catopocerus alabamae 6520182`
+
+Investigating this taxon using `bin/investigate "Catopocerus alabamae"`:
+
+```
+r/gbif-HEAD/resource/taxonomy.tsv:9360603	|	4760120	|	Catopocerus alabamae	|	species	|
+r/ott-PREVIOUS/source/taxonomy.tsv:6520182	|	5807594	|	Catopocerus alabamae	|	species	|	additions-6520182-6520186:6520182	|		|	sibling_higher	|
+r/ott-NEW/source/taxonomy.tsv:6520182	|	3344074	|	Catopocerus alabamae	|	species	|	gbif:9360603	|	|
+
+```
+
+Searching the amendments repo for this taxon leads us to [additions-6520182-6520186.json](https://github.com/OpenTreeOfLife/amendments-1/blob/c8c6d4cb29549c7c2fbc75a233d332ccdc129ffd/amendments/additions-6520182-6520186.json), where the author provides a reference that some of the taxa in Catopocerus were transferred to Pinodytes. Because we have Catopocerus as a synonym of Pinodytes, they instead try to move those taxa to subfamily Catopocerinae.
+
+This is a case where our amendments functionality is too limited for what the curator wants to do. 
+
+
 ## Testing
 
 ### Building OTT is a test
@@ -523,7 +547,7 @@ An attempt has been made to provide useful information when a test
 fails.  A taxon can disappear, or its OTT id can change, or the
 relationship may fail to hold, perhaps due to a merge or a split.
 
-    
+
 ## Troubleshooting
 
 Some tools to use
@@ -538,13 +562,13 @@ lineage of the given taxon.
 Tabs are helpful in picking out a genus record (as opposed to all
 species in the genus).  `^` is useful for lookup by id.  E.g.
 
-    grep "Peripatus dominicae" r/ott-NEW/source/taxonomy.tsv 
+    grep "Peripatus dominicae" r/ott-NEW/source/taxonomy.tsv
 
 `log.txt` shows alignment, merge, and other events connected with
 certain names.  To force logging for a name, if it's not already being
 logged, add it to the `names_of_interest` list in assemble_ott.py.
 
-    grep -A 2 Campanella r/ott-NEW/source/choices.tsv 
+    grep -A 2 Campanella r/ott-NEW/source/choices.tsv
 
 `choices.txt` shows alignment choices that were made, whenever there
 were two or more options.

--- a/import_scripts/gbif/project.py
+++ b/import_scripts/gbif/project.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+# That's pro-ject' with the emphasis on the 2nd syllable.
+
 # Python on my mac is not configured to pick up
 # up packages in site-package in /usr/local (I am using the
 # Apple-provided python)
@@ -8,79 +12,127 @@ sys.path.append('/usr/local/lib/python2.7/site-packages')
 # pip install python-dwca-reader
 # For documentation, see: http://python-dwca-reader.readthedocs.io/en/latest/index.html
 from dwca.read import DwCAReader
-from dwca.darwincore.utils import qualname as qn
+from dwca.darwincore.utils import qualname
 
 # '/Users/jar/a/ot/repo/reference-taxonomy/r/gbif-20160729/source/gbif-backbone.zip'
 
-archive = sys.argv[1]
-print 'archive is', archive
+# The columns we want in outfile:
+#   taxonID
+#   parentNameUsageID
+#   acceptedNameUsageID
+#   scientificName or canonicalName
+#   taxonRank
+#   taxonomicStatus
+#   datasetID (formerly nameAccordingTo)
 
-print '1'
+scientific_name_uri = qualname('scientificName')
+canonical_name_uri = 'http://rs.gbif.org/terms/1.0/canonicalName'
+
+taxon_id_uri = qualname('taxonID')
+
+column_uris = [qualname('taxonID'),
+               qualname('parentNameUsageID'),
+               qualname('acceptedNameUsageID'),
+               canonical_name_uri,
+               qualname('taxonRank'),
+               qualname('taxonomicStatus'),
+               qualname('datasetID')]
 
 def project_gbif(inpath, outpath):
 
+    print 'Opening archive', inpath
+
     with DwCAReader(inpath) as dwca:
 
-        print '2'
+        print 'Opened.  Core file has type', dwca.descriptor.core.type
         sys.stdout.flush()
 
-        print 'Core file has type', dwca.descriptor.core.type
-        sys.stdout.flush()
-
-        print 'Terms are', map(lambda (x): x.split('/')[-1], dwca.descriptor.core.terms)
-        sys.stdout.flush()
-
-        # The columns we want in outfile:
-        #   taxonID
-        #   parentNameUsageID
-        #   acceptedNameUsageID
-        #   scientificName or canonicalName
-        #   taxonRank
-        #   taxonomicStatus
-        #   datasetID (formerly nameAccordingTo)
-
-        columns = ['taxonID',
-                   'parentNameUsageID',
-                   'acceptedNameUsageID',
-                   'canonicalName',
-                   'taxonRank',
-                   'taxonomicStatus',
-                   'datasetID']
-
-        column_uris = map(qn, columns)
-        canonical_name_uri = qn('canonicalName')
-        scientific_name_uri = qn('scientificName')
-
-        def get_qn(shortname):
-            q = qn(shortname)
-            if q in column_uris:
-                return q
-            else:
-                print 'Did not find term:', shortname
-                return None
+        terms = {term:True for term in dwca.descriptor.core.terms}
+        if True:
+            print 'Columns in DwCA are:'
+            for uri in terms:
+                print ' ', uri
+            sys.stdout.flush()
 
         def get_value(row, uri):
-            if uri in row:
-                value = row[uri]
+            if uri in terms:
+                value = row.data[uri]
             elif uri == scientific_name_uri:
                 # Assume the library has taken care of utf-8 issues for us
-                value = canonical_name(row[canonical_name_uri])
+                value = canonical_name(row.data[canonical_name_uri])
+            elif uri == taxon_id_uri:
+                value = row.id
             else:
-                print '** field is required but missing:', uri
+                print '** Field is required but missing:', uri
+                value = ''
             return value
 
         with open(outpath, 'w') as outfile:
             i = 0
             for row in dwca:
-                outfile.write('\t'.join(map(lambda uri: get_value(row, uri).encode('utf-8'), columns)))
-            i += 1
-            if i % 100000 == 0: print i, scientific.encode('utf-8'), '=>', canenc
+                outfile.write('\t'.join(map(lambda uri: get_value(row, uri).encode('utf-8'),
+                                            column_uris)))
+                outfile.write('\n')
+                i += 1
+                if i % 50000 == 0: print i
 
-# Needed for 2016 GBIF, but not for later or earlier ones
+# canonical_name() is needed for 2016 GBIF, but not for later or earlier ones
+import re
 
-def canonical_name(scientific_name):
-    print '** NYI'
-    return 'uluz'
+# Cases to deal with:
+#  Foo bar
+#  Foo bar Putnam
+#  Foo bar Putnam, 1972
+#  Foo bar Putnam, 4723     no authority
+#  Foo bar Putnam 1972      no authority (in GBIF)
+#  Enterobacteria phage PA-2
+#  Ajuga pyramidalis L.	
+
+lower = u"a-záåäàãçëéèïíøöóü'×?"
+upper = u"A-ZÄÁÅÁÁÇČÐĎĐÉÉÎİŁŘŠŚŞȘÔØÖÔÓÜÚŽ"
+
+epithet = u" +[%s0-9.-]+" % lower
+
+# Matches a canonical name
+canon_re = u"[A-ZÖ%s-]+(|%s|%s%s|%s%s%s)" % (lower, epithet, epithet, epithet, epithet, epithet, epithet)
+
+auth_re = u" +(d'|von |van |de |dem |der |da |del |di |le |f\\. |[%s(])(..|\\.).*" % (upper)
+
+trimmer = re.compile(u"(%s)(%s)" % (canon_re, auth_re))
+
+year_re = re.compile(u".*, [12][0-9][0-9][0-9?]\\)?")
+
+has_digit = re.compile(u".*[0-9].*")
+
+count = 0
+
+def canonical_name(name):
+    global count
+    if ' phage ' in name or name.endswith(' phage'): return name
+    if ' virus ' in name or name.endswith(' virus'): return name
+    m = trimmer.match(name)
+    if m != None:
+        canon = m.group(1)
+        # group 1 = canonical name
+        # group 2 = epithet(s)
+        # group 3 = authority
+        # group 4 = capital letter or prefix
+        if has_digit.match(name):
+            haz = year_re.match(name) != None
+        else:
+            haz = True
+        if count < 30 and not haz:
+            print "%s '%s' '%s'" % (('+' if haz else '-'), name, canon)
+            count += 1
+        if haz:
+            if canon == 'Enterobacteria phage':
+                print '! %s => %s' % (name, canon)
+            return canon
+        else:
+            return name
+    else:
+        return name
+
 
 if __name__ == '__main__':
     project_gbif(sys.argv[1], sys.argv[2])

--- a/import_scripts/gbif/project.py
+++ b/import_scripts/gbif/project.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+# Import script for DwC version of GBIF
+
 # That's pro-ject' with the emphasis on the 2nd syllable.
 
 # Python on my mac is not configured to pick up
@@ -86,7 +88,7 @@ import re
 #  Foo bar Putnam, 4723     no authority
 #  Foo bar Putnam 1972      no authority (in GBIF)
 #  Enterobacteria phage PA-2
-#  Ajuga pyramidalis L.	
+#  Ajuga pyramidalis L.
 
 lower = u"a-záåäàãçëéèïíøöóü'×?"
 upper = u"A-ZÄÁÅÁÁÇČÐĎĐÉÉÎİŁŘŠŚŞȘÔØÖÔÓÜÚŽ"

--- a/import_scripts/gbif/project.py
+++ b/import_scripts/gbif/project.py
@@ -1,0 +1,86 @@
+# Python on my mac is not configured to pick up
+# up packages in site-package in /usr/local (I am using the
+# Apple-provided python)
+import sys
+sys.path.append('/usr/local/lib/python2.7/site-packages')
+
+# To install 'dwca':
+# pip install python-dwca-reader
+# For documentation, see: http://python-dwca-reader.readthedocs.io/en/latest/index.html
+from dwca.read import DwCAReader
+from dwca.darwincore.utils import qualname as qn
+
+# '/Users/jar/a/ot/repo/reference-taxonomy/r/gbif-20160729/source/gbif-backbone.zip'
+
+archive = sys.argv[1]
+print 'archive is', archive
+
+print '1'
+
+def project_gbif(inpath, outpath):
+
+    with DwCAReader(inpath) as dwca:
+
+        print '2'
+        sys.stdout.flush()
+
+        print 'Core file has type', dwca.descriptor.core.type
+        sys.stdout.flush()
+
+        print 'Terms are', map(lambda (x): x.split('/')[-1], dwca.descriptor.core.terms)
+        sys.stdout.flush()
+
+        # The columns we want in outfile:
+        #   taxonID
+        #   parentNameUsageID
+        #   acceptedNameUsageID
+        #   scientificName or canonicalName
+        #   taxonRank
+        #   taxonomicStatus
+        #   datasetID (formerly nameAccordingTo)
+
+        columns = ['taxonID',
+                   'parentNameUsageID',
+                   'acceptedNameUsageID',
+                   'canonicalName',
+                   'taxonRank',
+                   'taxonomicStatus',
+                   'datasetID']
+
+        column_uris = map(qn, columns)
+        canonical_name_uri = qn('canonicalName')
+        scientific_name_uri = qn('scientificName')
+
+        def get_qn(shortname):
+            q = qn(shortname)
+            if q in column_uris:
+                return q
+            else:
+                print 'Did not find term:', shortname
+                return None
+
+        def get_value(row, uri):
+            if uri in row:
+                value = row[uri]
+            elif uri == scientific_name_uri:
+                # Assume the library has taken care of utf-8 issues for us
+                value = canonical_name(row[canonical_name_uri])
+            else:
+                print '** field is required but missing:', uri
+            return value
+
+        with open(outpath, 'w') as outfile:
+            i = 0
+            for row in dwca:
+                outfile.write('\t'.join(map(lambda uri: get_value(row, uri).encode('utf-8'), columns)))
+            i += 1
+            if i % 100000 == 0: print i, scientific.encode('utf-8'), '=>', canenc
+
+# Needed for 2016 GBIF, but not for later or earlier ones
+
+def canonical_name(scientific_name):
+    print '** NYI'
+    return 'uluz'
+
+if __name__ == '__main__':
+    project_gbif(sys.argv[1], sys.argv[2])

--- a/import_scripts/gbif/project_2016.py
+++ b/import_scripts/gbif/project_2016.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+# Import script for txt version of GBIF - use project.py for DwC format
+
 # In principle the column numbers could be extracted programmatically
 # from meta.xml
 
@@ -37,7 +39,7 @@ def project_2016_gbif(inpath, outpath):
 #  Foo bar Putnam, 4723     no authority
 #  Foo bar Putnam 1972      no authority (in GBIF)
 #  Enterobacteria phage PA-2
-#  Ajuga pyramidalis L.	
+#  Ajuga pyramidalis L.
 
 
 lower = u"a-záåäàãçëéèïíøöóü'×?"
@@ -96,5 +98,5 @@ def canonical_name(name):
 
 project_2016_gbif(sys.argv[1], sys.argv[2])
 
-# QC check: 
+# QC check:
 #  grep " [0-9][0-9][0-9][0-9]	" feed/gbif/work/projection_2016.tsv  >tmp.tmp


### PR DESCRIPTION
In future, might be a good idea to make this fully general so we can use it with IRMNG and other DwCA sources, but this version is what we need right now (2018) for updating GBIF.

Should work with both the GBIF version from which OTT 3.0 was built, and with newer versions.

I think this code works, but it might be nice to test it once more (especially the way it installs the libraries it needs) before merging to master.