### PR TITLE
Change include config.mk to -include config.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ AMENDMENTS_ORIGIN_URL=https://github.com/OpenTreeOfLife/amendments-1.git
 
 # ----- Version selection -----
 
-include config.mk
+-include config.mk
 
 fetch: $(FETCHES)
 


### PR DESCRIPTION
When using smasher, but not building a taxonomy, we were getting errors saying that config.mk is missing.  This change makes it OK for config.mk to be missing; it is not needed for server operation.