### PR TITLE
Converting all download links to HTTPS

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -4,10 +4,10 @@
 * [Version 2.8](ott2.8.md) 2014-06-12
 * [Version 2.7](ott2.7.md) 2014-05-08
 * [Version 2.6](ott2.6.md) 2014-04-11
-* Version 2.5 2014-03-28 (no release notes) [gzipped tar file, 83 Mbyte](http://files.opentreeoflife.org/ott/ott2.5/ott2.5.tgz)
+* Version 2.5 2014-03-28 (no release notes) [gzipped tar file, 83 Mbyte](https://files.opentreeoflife.org/ott/ott2.5/ott2.5.tgz)
 * [Version 2.4](ott2.4.md) 2014-03-17
 * [Version 2.3](ott2.3.md) 2013-12-04
-* Version 2.2 2013-09-15 (no release notes) [gzipped tar file, 123 Mbyte](http://files.opentreeoflife.org/ott/ott2.2/ott2.2.tgz)
+* Version 2.2 2013-09-15 (no release notes) [gzipped tar file, 123 Mbyte](https://files.opentreeoflife.org/ott/ott2.2/ott2.2.tgz)
 * [Version 2.1](ott2.1.md) 2013-07-16
 * [Version 2.0](ott2.0.md) 2013-05-31
 * [Version 1.0](ott1.0.md) 2013-03-16

--- a/doc/maintenance/new-release.md
+++ b/doc/maintenance/new-release.md
@@ -257,8 +257,8 @@ and stores them on the files server:
     make store-all
 
 Find the tarballs as
-`http://files.openetreeoflife.org/ott/ott3.1/ott3.1.tgz`,
-`http://files.openetreeoflife.org/ncbi/ncbi-20170523/ncbi-20170523.tgz`,
+`https://files.openetreeoflife.org/ott/ott3.1/ott3.1.tgz`,
+`https://files.openetreeoflife.org/ncbi/ncbi-20170523/ncbi-20170523.tgz`,
 and so on.
 
 

--- a/doc/ott2.0.md
+++ b/doc/ott2.0.md
@@ -2,7 +2,7 @@
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.0/ott2.0.tgz) (gzipped tar file, 62 Mbyte) 
+[Download](https://files.opentreeoflife.org/ott/ott2.0/ott2.0.tgz) (gzipped tar file, 62 Mbyte) 
 
 ## Release notes
 

--- a/doc/ott2.1.md
+++ b/doc/ott2.1.md
@@ -2,7 +2,7 @@
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.1/ott2.1.tgz) (gzipped tar file, 120 Mbyte) 
+[Download](https://files.opentreeoflife.org/ott/ott2.1/ott2.1.tgz) (gzipped tar file, 120 Mbyte) 
 
 ## Release notes
 

--- a/doc/ott2.10.md
+++ b/doc/ott2.10.md
@@ -4,7 +4,7 @@ Version 2.10 draft 11 was generated on 10 September 2016.
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.10/ott2.10.tgz)
+[Download](https://files.opentreeoflife.org/ott/ott2.10/ott2.10.tgz)
 
 ## Major changes since OTT 2.9
 
@@ -109,7 +109,7 @@ retrieved.
     Kirk, 7 April 2014 (personal communication).
     Web site: [http://www.indexfungorum.org/](http://www.indexfungorum.org/).
     <br />
-    Download location (converted to OTT format): [http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
+    Download location (converted to OTT format): [https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
 
 1.  Taxonomy from:
     Sch&auml;ferhoff, B., Fleischmann, A., Fischer, E., Albach, D. C., Borsch,
@@ -122,14 +122,14 @@ retrieved.
     Download location: [http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv](http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv)
 
 1.  [World Register of Marine Species (WoRMS)](http://www.marinespecies.org/aphia.php) - harvested from web site using web API over several days ending around 1 October 2015.
-    Download location: [http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
+    Download location: [https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
 
 1.  NCBI Taxonomy, from the 
     [US National Center on Biotechnology Information](http://www.ncbi.nlm.nih.gov/).
     Web site: [http://www.ncbi.nlm.nih.gov/Taxonomy/](http://www.ncbi.nlm.nih.gov/Taxonomy/).
     <br />
     For OTT 2.10 we used a version downloaded from NCBI on 29 June 2016.
-    Download location: [http://files.opentreeoflife.org/ncbi/ncbi-20151006/ncbi-20151006.tgz](http://files.opentreeoflife.org/ncbi/ncbi-20151006/ncbi-20151006.tgz).
+    Download location: [https://files.opentreeoflife.org/ncbi/ncbi-20151006/ncbi-20151006.tgz](https://files.opentreeoflife.org/ncbi/ncbi-20151006/ncbi-20151006.tgz).
     <br />
     Current version download location:
     [ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz](ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz)

--- a/doc/ott2.2.md
+++ b/doc/ott2.2.md
@@ -2,6 +2,6 @@
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.2/ott2.2.tgz) (gzipped tar file, 123 Mbyte) 
+[Download](https://files.opentreeoflife.org/ott/ott2.2/ott2.2.tgz) (gzipped tar file, 123 Mbyte) 
 
 ## Release notes

--- a/doc/ott2.3.md
+++ b/doc/ott2.3.md
@@ -2,7 +2,7 @@
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.3/ott2.3.tgz) (gzipped tar file, 89 Mbyte) 
+[Download](https://files.opentreeoflife.org/ott/ott2.3/ott2.3.tgz) (gzipped tar file, 89 Mbyte) 
 
 ## Release notes
 

--- a/doc/ott2.4.md
+++ b/doc/ott2.4.md
@@ -7,7 +7,7 @@ Released 17 March 2014.
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.4/ott2.4.tgz) (gzipped tar file, 84 Mbyte) 
+[Download](https://files.opentreeoflife.org/ott/ott2.4/ott2.4.tgz) (gzipped tar file, 84 Mbyte) 
 
 ## Change log
 

--- a/doc/ott2.6.md
+++ b/doc/ott2.6.md
@@ -7,7 +7,7 @@ f624223f31](https://github.com/OpenTreeOfLife/reference-taxonomy/commit/f624223f
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.6/ott2.6.tgz) (gzipped tar file, 94 Mbyte) 
+[Download](https://files.opentreeoflife.org/ott/ott2.6/ott2.6.tgz) (gzipped tar file, 94 Mbyte) 
 
 ## Files in this package
 
@@ -116,4 +116,4 @@ f624223f31](https://github.com/OpenTreeOfLife/reference-taxonomy/commit/f624223f
 *  OTT version 2.5:
     The previous version of OTT is used only for the purpose of ensuring
     identifier choice consistency from one version of OTT to the next.
-      [http://purl.org/opentree/ott/ott2.5.tgz](http://purl.org/opentree/ott/ott2.5.tgz)
+      [https://purl.org/opentree/ott/ott2.5.tgz](https://purl.org/opentree/ott/ott2.5.tgz)

--- a/doc/ott2.7.md
+++ b/doc/ott2.7.md
@@ -5,7 +5,7 @@ OTT 2.7 was created on or shortly before 8 May 2014.
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.7/ott2.7.tgz) (gzipped tar file, 102 Mbyte) 
+[Download](https://files.opentreeoflife.org/ott/ott2.7/ott2.7.tgz) (gzipped tar file, 102 Mbyte) 
 
 ## Release notes
 

--- a/doc/ott2.8.md
+++ b/doc/ott2.8.md
@@ -4,7 +4,7 @@ Version 2.8 (also known as version 2.8 draft 5) was generated on 11 June 2014.
 
 ## Download
 
-[Download](http://purl.org/opentree/ott/ott2.8/ott2.8.tgz) (gzipped tar file, 119 Mbyte) 
+[Download](https://purl.org/opentree/ott/ott2.8/ott2.8.tgz) (gzipped tar file, 119 Mbyte) 
 
 ## Contents
 All files are encoded UTF-8.  For detailed documentation about file formats, see [documentation in the reference taxonomy
@@ -86,7 +86,7 @@ retrieved.
     Kirk, April 2014 (personal communication).
     Web site: [http://www.indexfungorum.org/](http://www.indexfungorum.org/).
     <br />
-    Download location (converted to OTT format): [http://purl.org/opentree/ott/ott2.8/inputs/if-20140514.tgz](http://purl.org/opentree/ott/ott2.8/inputs/if-20140514.tgz).
+    Download location (converted to OTT format): [https://purl.org/opentree/ott/ott2.8/inputs/if-20140514.tgz](https://purl.org/opentree/ott/ott2.8/inputs/if-20140514.tgz).
 
 1.  Taxonomy from:
     Sch&auml;ferhoff, B., Fleischmann, A., Fischer, E., Albach, D. C., Borsch,
@@ -105,7 +105,7 @@ retrieved.
     [ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz](ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz)
     <br />
     For OTT 2.8 we used a version dated circa 11 June 2014.
-    Download location: [http://purl.org/opentree/ott/ott2.8/inputs/taxdump-20140611.tgz](http://purl.org/opentree/ott/ott2.8/inputs/taxdump-20140611.tgz).
+    Download location: [https://purl.org/opentree/ott/ott2.8/inputs/taxdump-20140611.tgz](https://purl.org/opentree/ott/ott2.8/inputs/taxdump-20140611.tgz).
   </li>
 
 1.  GBIF Backbone Taxonomy, from the 

--- a/doc/ott2.9.md
+++ b/doc/ott2.9.md
@@ -4,7 +4,7 @@ Version 2.9 draft 12 was generated on 12 October 2015.  Draft 12 is the final dr
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott2.9/ott2.9.tgz) (gzipped tar file, 91 Mbyte) 
+[Download](https://files.opentreeoflife.org/ott/ott2.9/ott2.9.tgz) (gzipped tar file, 91 Mbyte) 
 
 ## Contents
 All files are encoded UTF-8.  For documentation about file formats, see [the documentation in the reference taxonomy

--- a/doc/ott3.0.md
+++ b/doc/ott3.0.md
@@ -10,7 +10,7 @@ Version 3.0 draft 6 was generated on 26 February 2017.
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott3.0/ott3.0.tgz)
+[Download](https://files.opentreeoflife.org/ott/ott3.0/ott3.0.tgz)
 
 ## Major changes since OTT 2.10
 
@@ -123,7 +123,7 @@ retrieved.
     Kirk, 7 April 2014 (personal communication).
     Web site: [http://www.indexfungorum.org/](http://www.indexfungorum.org/).
     <br />
-    Download location (converted to OTT format): [http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
+    Download location (converted to OTT format): [https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
 
 1.  Taxonomy from:
     Sch&auml;ferhoff, B., Fleischmann, A., Fischer, E., Albach, D. C., Borsch,
@@ -136,14 +136,14 @@ retrieved.
     Download location: [http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv](http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv)
 
 1.  [World Register of Marine Species (WoRMS)](http://www.marinespecies.org/aphia.php) - harvested from web site using web API over several days ending around 1 October 2015.
-    Download location: [http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
+    Download location: [https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
 
 1.  NCBI Taxonomy, from the 
     [US National Center on Biotechnology Information](http://www.ncbi.nlm.nih.gov/).
     Web site: [http://www.ncbi.nlm.nih.gov/Taxonomy/](http://www.ncbi.nlm.nih.gov/Taxonomy/).
     <br />
     We used a version dated 9 November 2016.
-    Archived location: [http://files.opentreeoflife.org/ncbi/ncbi-20151006/ncbi-20151006.tgz](http://files.opentreeoflife.org/ncbi/ncbi-20161109/ncbi-20161109.tgz).
+    Archived location: [https://files.opentreeoflife.org/ncbi/ncbi-20151006/ncbi-20151006.tgz](https://files.opentreeoflife.org/ncbi/ncbi-20161109/ncbi-20161109.tgz).
     <br />
     Current version download location:
     [ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz](ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz)

--- a/doc/ott3.1.md
+++ b/doc/ott3.1.md
@@ -4,7 +4,7 @@ Version 3.1 draft 2 was generated on 16 September, 2019.
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott3.1/ott3.1.tgz)
+[Download](https://files.opentreeoflife.org/ott/ott3.1/ott3.1.tgz)
 
 ## Major changes since OTT 3.0
 
@@ -78,7 +78,7 @@ retrieved.
     Kirk, 7 April 2014 (personal communication).
     Web site: [http://www.indexfungorum.org/](http://www.indexfungorum.org/).
     <br />
-    Download location (converted to OTT format): [http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
+    Download location (converted to OTT format): [https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
 
 1.  Taxonomy from:
     Sch&auml;ferhoff, B., Fleischmann, A., Fischer, E., Albach, D. C., Borsch,
@@ -91,14 +91,14 @@ retrieved.
     Download location: [http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv](http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv)
 
 1.  [World Register of Marine Species (WoRMS)](http://www.marinespecies.org/aphia.php) - harvested from web site using web API over several days ending around 1 October 2015.
-    Download location: [http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
+    Download location: [https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
 
 1.  NCBI Taxonomy, from the 
     [US National Center on Biotechnology Information](http://www.ncbi.nlm.nih.gov/).
     Web site: [http://www.ncbi.nlm.nih.gov/Taxonomy/](http://www.ncbi.nlm.nih.gov/Taxonomy/).
     <br />
     We used a version dated 16 September, 2019.
-    Archived location: [http://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz](http://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz).
+    Archived location: [https://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz](https://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz).
     <br />
     Current version download location:
     [ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz](ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz)

--- a/doc/ott3.2.md
+++ b/doc/ott3.2.md
@@ -4,7 +4,7 @@ Version 3.2 draft 9 was generated on 30 October, 2019.
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott3.2/ott3.2.tgz)
+[Download](https://files.opentreeoflife.org/ott/ott3.2/ott3.2.tgz)
 
 ## Major changes since OTT 3.1
 
@@ -78,7 +78,7 @@ retrieved.
     Kirk, 7 April 2014 (personal communication).
     Web site: [http://www.indexfungorum.org/](http://www.indexfungorum.org/).
     <br />
-    Download location (converted to OTT format): [http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
+    Download location (converted to OTT format): [https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
 
 1.  Taxonomy from:
     Sch&auml;ferhoff, B., Fleischmann, A., Fischer, E., Albach, D. C., Borsch,
@@ -91,14 +91,14 @@ retrieved.
     Download location: [http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv](http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv)
 
 1.  [World Register of Marine Species (WoRMS)](http://www.marinespecies.org/aphia.php) - harvested from web site using web API over several days ending around 1 October 2015.
-    Download location: [http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
+    Download location: [https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
 
 1.  NCBI Taxonomy, from the 
     [US National Center on Biotechnology Information](http://www.ncbi.nlm.nih.gov/).
     Web site: [http://www.ncbi.nlm.nih.gov/Taxonomy/](http://www.ncbi.nlm.nih.gov/Taxonomy/).
     <br />
     We used a version dated 16 September, 2019.
-    Archived location: [http://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz](http://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz).
+    Archived location: [https://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz](https://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz).
     <br />
     Current version download location:
     [ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz](ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz)

--- a/doc/ott3.3.md
+++ b/doc/ott3.3.md
@@ -4,7 +4,7 @@ Version 3.3 draft 1 was generated on 01 June, 2021.
 
 ## Download
 
-[Download](http://files.opentreeoflife.org/ott/ott3.3/ott3.3.tgz)
+[Download](https://files.opentreeoflife.org/ott/ott3.3/ott3.3.tgz)
 
 ## Major changes since OTT 3.2
 
@@ -88,7 +88,7 @@ retrieved.
     Kirk, 7 April 2014 (personal communication).
     Web site: [http://www.indexfungorum.org/](http://www.indexfungorum.org/).
     <br />
-    Download location (converted to OTT format): [http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](http://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
+    Download location (converted to OTT format): [https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz](https://files.opentreeoflife.org/fung/fung-9/fung-9-ot.tgz).
 
 1.  Taxonomy from:
     Sch&auml;ferhoff, B., Fleischmann, A., Fischer, E., Albach, D. C., Borsch,
@@ -101,14 +101,14 @@ retrieved.
     Download location: [http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv](http://purl.org/opentree/ott/ott2.8/inputs/lamiales-20140118.tsv)
 
 1.  [World Register of Marine Species (WoRMS)](http://www.marinespecies.org/aphia.php) - harvested from web site using web API over several days ending around 1 October 2015.
-    Download location: [http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](http://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
+    Download location: [https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz](https://files.opentreeoflife.org/worms/worms-1/worms-1-ot.tgz)
 
 1.  NCBI Taxonomy, from the 
     [US National Center on Biotechnology Information](http://www.ncbi.nlm.nih.gov/).
     Web site: [http://www.ncbi.nlm.nih.gov/Taxonomy/](http://www.ncbi.nlm.nih.gov/Taxonomy/).
     <br />
     We used a version dated 16 September, 2019.
-    Archived location: [http://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz](http://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz).
+    Archived location: [https://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz](https://files.opentreeoflife.org/ncbi/ncbi-20190916/ncbi-20190916.tgz).
     <br />
     Current version download location:
     [ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz](ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz)


### PR DESCRIPTION
The HTTP URLs will resolve in a new tab/window, but not (as of 2021)
when clicked in a typical web page. This is a problem for our About
pages in the tree-browser web app.